### PR TITLE
Fix: Uppercase support for alternative format games

### DIFF
--- a/bleemsync/etc/bleemsync/SUP/scripts/intercept
+++ b/bleemsync/etc/bleemsync/SUP/scripts/intercept
@@ -130,8 +130,14 @@ do
 
       start_alt=$(date +%s%N)
       for f in "${intercept_file_formats[@]}"; do
-        intercept_game_alternative_path="${arg%.cue}.${f}"
-        if [ -f "$intercept_game_alternative_path" ]; then
+        f_upper=$(echo $f | tr a-z A-Z)
+        if [ -f "${arg%.cue}.${f}" ]; then
+          intercept_game_alternative_path="${arg%.cue}.${f}"
+        elif [ -f "${arg%.cue}.${f_upper}" ]; then
+          intercept_game_alternative_path="${arg%.cue}.${f_upper}"
+          f=$f_upper
+        fi
+        if [ ! -z "$intercept_game_alternative_path" ]; then
           echo "[INTERCEPT](INFO) Alternative game format exists (${f}), this will be used instead of the .cue"
           arg="$intercept_game_alternative_path"
           intercept_game_path="$arg"


### PR DESCRIPTION
The intercept script only supported launching alternative PCSX game formats if the extension was in lowercase. This fix enables support for either uppercase or lowercase.

Related issue https://github.com/pathartl/BleemSync/issues/278

.cue will always be lower case, every other format could be either